### PR TITLE
feat: add new line_ field to OrderItem and OrderItemAddition models

### DIFF
--- a/order/tests/modles/test_order_item_models.py
+++ b/order/tests/modles/test_order_item_models.py
@@ -1,0 +1,50 @@
+from decimal import Decimal
+
+from django.core.validators import ValidationError
+from django.test import TestCase
+from model_bakery import baker
+
+from order.models import OrderItem
+
+
+class TestOrderItem(TestCase):
+    def _make_order_item_models(self, **kwargs):
+        return baker.make(OrderItem, **kwargs)
+
+    def test_order_item_line_total(self):
+        """Should calculate raw cost for Item"""
+        price_snapshot = 10
+        quantity = 2
+        order_item_instance = self._make_order_item_models(
+            price_snapshot=price_snapshot, quantity=quantity
+        )
+        expected = Decimal(price_snapshot * quantity)
+        self.assertEqual(order_item_instance.line_subtotal, expected)
+
+    def test_order_item_line_total_after(self):
+        """Should return price without discount"""
+        price_snapshot = 10
+        quantity = 2
+        line_discount_amount = Decimal("10.00")
+        order_item_instance = self._make_order_item_models(
+            price_snapshot=price_snapshot,
+            quantity=quantity,
+            line_discount_amount=line_discount_amount,
+        )
+        expected = Decimal(price_snapshot * quantity) - line_discount_amount
+        self.assertEqual(order_item_instance.line_final_total, expected)
+
+    def test_should_not_allow_negative_line_total_after(self):
+        """Should not allow negative line_total_after"""
+        price_snapshot = 10
+        quantity = 2
+        line_discount_amount = Decimal("21.00")
+
+        with self.assertRaises(ValidationError):
+            self._make_order_item_models(
+                price_snapshot=price_snapshot,
+                quantity=quantity,
+                line_discount_amount=line_discount_amount,
+            )
+
+        self.assertEqual(OrderItem.objects.count(), 0)


### PR DESCRIPTION
This pull request introduce new fields to simplify revenue calculations.
The following fields have been added:
* `line_subtotal` to calculate revenue before discount
* `line_discount_amount` stores the discount applied from the Bill
* `line_final_total` - stores the final revenue value 
* `quantity` added only to `OrderItemAddition`; be default, its value matches `OrderItem.quantity`

These changes are the first step toward simplifying revenue reporting.
The next step will be to update the ordering logic to use the new structure.